### PR TITLE
Refine branding with logo and active navigation

### DIFF
--- a/hair.html
+++ b/hair.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Парикмахерские услуги в Studiya Ludmila: стрижки, окрашивание и укладки."
+    />
+    <title>Парикмахер</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&family=Playfair+Display:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="branding">
+        <img
+          src="photo/logo/logo.png"
+          alt="Studiya Ludmila logo"
+          class="logo"
+        />
+        <h1>Studiya Ludmila</h1>
+      </div>
+      <nav>
+        <a href="index.html">Главная</a>
+        <a href="permanent.html">Перманентный макияж</a>
+        <a href="hair.html" class="active">Парикмахер</a>
+        <a href="massage.html">Массаж</a>
+        <a href="manicure.html">Маникюр</a>
+        <a href="laser.html">Лазерные процедуры</a>
+      </nav>
+    </header>
+    <main>
+      <section class="hero">
+        <h2>Парикмахер</h2>
+        <p>
+          Смелые стрижки, трендовые окрашивания и укладки — доверяйте
+          профессионалам и меняйте образ легко.
+        </p>
+        <a href="#services" class="cta-button">Записаться</a>
+      </section>
+      <section id="services">
+        <div>
+          <h3>Стрижка</h3>
+          <p>
+            Подбор и выполнение стрижек любой сложности с учётом ваших
+            пожеланий.
+          </p>
+        </div>
+        <div>
+          <h3>Окрашивание</h3>
+          <p>Современные техники окрашивания для создания стильного образа.</p>
+        </div>
+        <div>
+          <h3>Укладка</h3>
+          <p>Праздничные и повседневные укладки для любого события.</p>
+        </div>
+        <div class="photo-placeholder"></div>
+      </section>
+    </main>
+    <footer>
+      <p>© Studiya Ludmila, 2023</p>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Studiya Ludmila: перманентный макияж, парикмахер, массаж, маникюр и лазерные процедуры."
+    />
+    <title>Studiya Ludmila</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&family=Playfair+Display:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="branding">
+        <img
+          src="photo/logo/logo.png"
+          alt="Studiya Ludmila logo"
+          class="logo"
+        />
+        <h1>Studiya Ludmila</h1>
+      </div>
+      <nav>
+        <a href="index.html" class="active">Главная</a>
+        <a href="permanent.html">Перманентный макияж</a>
+        <a href="hair.html">Парикмахер</a>
+        <a href="massage.html">Массаж</a>
+        <a href="manicure.html">Маникюр</a>
+        <a href="laser.html">Лазерные процедуры</a>
+      </nav>
+    </header>
+    <main>
+      <section class="hero">
+        <h2>Добро пожаловать в Studiya Ludmila</h2>
+        <p>
+          Откройте для себя мир красоты: от перманентного макияжа и маникюра до
+          массажа и лазерных процедур. Доверьтесь профессионалам и подчеркните
+          свою индивидуальность.
+        </p>
+        <a href="permanent.html" class="cta-button">Записаться</a>
+        <div class="hero-photo"></div>
+      </section>
+    </main>
+    <footer>
+      <p>© Studiya Ludmila, 2023</p>
+    </footer>
+  </body>
+</html>

--- a/laser.html
+++ b/laser.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Лазерное удаление тату и татуажа, карбоновый пилинг в Studiya Ludmila."
+    />
+    <title>Лазерные процедуры</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&family=Playfair+Display:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="branding">
+        <img
+          src="photo/logo/logo.png"
+          alt="Studiya Ludmila logo"
+          class="logo"
+        />
+        <h1>Studiya Ludmila</h1>
+      </div>
+      <nav>
+        <a href="index.html">Главная</a>
+        <a href="permanent.html">Перманентный макияж</a>
+        <a href="hair.html">Парикмахер</a>
+        <a href="massage.html">Массаж</a>
+        <a href="manicure.html">Маникюр</a>
+        <a href="laser.html" class="active">Лазерные процедуры</a>
+      </nav>
+    </header>
+    <main>
+      <section class="hero">
+        <h2>Лазерные процедуры</h2>
+        <p>
+          Современные технологии для чистой и сияющей кожи: безопасное удаление
+          тату и татуажа, мгновенное обновление с карбоновым пилингом.
+        </p>
+        <a href="#tattooage" class="cta-button">Записаться</a>
+      </section>
+      <section id="tattooage">
+        <h3>Удаление татуажа</h3>
+        <p>
+          Безболезненно избавим от старого перманентного макияжа. Уже после
+          нескольких сеансов кожа вновь чистая и свежая.
+        </p>
+        <table class="price">
+          <tr>
+            <th>Услуга</th>
+            <th>Время</th>
+            <th>Цена</th>
+          </tr>
+          <tr>
+            <td>Видалення брів</td>
+            <td>30 хв</td>
+            <td>600 грн</td>
+          </tr>
+          <tr>
+            <td>Видалення губ (контур)</td>
+            <td>30 хв</td>
+            <td>600 грн</td>
+          </tr>
+          <tr>
+            <td>Видалення губ (помада)</td>
+            <td>30 хв</td>
+            <td>600 грн</td>
+          </tr>
+        </table>
+        <div class="photo-placeholder"></div>
+      </section>
+      <section id="tattoo">
+        <h3>Удаление тату</h3>
+        <p>
+          Современный лазер бережно выводит нежелательные рисунки без шрамов.
+          Чем раньше начнёте, тем быстрее увидите чистую кожу.
+        </p>
+        <table class="price">
+          <tr>
+            <th>Услуга</th>
+            <th>Время</th>
+            <th>Цена</th>
+          </tr>
+          <tr>
+            <td>До 5 см</td>
+            <td>30 хв</td>
+            <td>480 грн</td>
+          </tr>
+          <tr>
+            <td>Від 5 до 15 см</td>
+            <td>30 хв</td>
+            <td>600 грн</td>
+          </tr>
+          <tr>
+            <td>Від 15 до 20 см</td>
+            <td>30 хв</td>
+            <td>780 грн</td>
+          </tr>
+          <tr>
+            <td>Від 20 до 30 см</td>
+            <td>30 хв</td>
+            <td>900 грн</td>
+          </tr>
+          <tr>
+            <td>Від 30 за кожен +1 см</td>
+            <td>30 хв</td>
+            <td>60 грн</td>
+          </tr>
+          <tr>
+            <td>Знеболення 1 зона</td>
+            <td>30 хв</td>
+            <td>60 грн</td>
+          </tr>
+        </table>
+        <div class="photo-placeholder"></div>
+      </section>
+      <section id="peeling">
+        <h3>Карбоновый пилинг</h3>
+        <p>
+          Быстрое обновление кожи без реабилитации: гладкость и сияние уже после
+          первого сеанса.
+        </p>
+        <table class="price">
+          <tr>
+            <th>Услуга</th>
+            <th>Время</th>
+            <th>Цена</th>
+          </tr>
+          <tr>
+            <td>Обличчя</td>
+            <td>30 хв</td>
+            <td>600 грн</td>
+          </tr>
+          <tr>
+            <td>Кисті рук</td>
+            <td>30 хв</td>
+            <td>540 грн</td>
+          </tr>
+          <tr>
+            <td>Декольте</td>
+            <td>30 хв</td>
+            <td>660 грн</td>
+          </tr>
+          <tr>
+            <td>Шия</td>
+            <td>30 хв</td>
+            <td>420 грн</td>
+          </tr>
+          <tr>
+            <td>Комплекс: обличчя + шия + декольте</td>
+            <td>60 хв</td>
+            <td>1500 грн</td>
+          </tr>
+          <tr>
+            <td>Спина</td>
+            <td>30 хв</td>
+            <td>1800 грн</td>
+          </tr>
+          <tr>
+            <td>1/3 спини</td>
+            <td>30 хв</td>
+            <td>900 грн</td>
+          </tr>
+        </table>
+        <div class="photo-placeholder"></div>
+      </section>
+    </main>
+    <footer>
+      <p>© Studiya Ludmila, 2023</p>
+    </footer>
+  </body>
+</html>

--- a/manicure.html
+++ b/manicure.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Маникюр и дизайн ногтей в Studiya Ludmila: красота и уход за руками."
+    />
+    <title>Маникюр</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&family=Playfair+Display:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="branding">
+        <img
+          src="photo/logo/logo.png"
+          alt="Studiya Ludmila logo"
+          class="logo"
+        />
+        <h1>Studiya Ludmila</h1>
+      </div>
+      <nav>
+        <a href="index.html">Главная</a>
+        <a href="permanent.html">Перманентный макияж</a>
+        <a href="hair.html">Парикмахер</a>
+        <a href="massage.html">Массаж</a>
+        <a href="manicure.html" class="active">Маникюр</a>
+        <a href="laser.html">Лазерные процедуры</a>
+      </nav>
+    </header>
+    <main>
+      <section class="hero">
+        <h2>Маникюр</h2>
+        <p>
+          Идеальные ногти – ваш лучший аксессуар. Мы создаём стильные образы и
+          заботимся о здоровье рук. Запишитесь на маникюр мечты!
+        </p>
+        <a href="#price" class="cta-button">Записаться</a>
+      </section>
+      <section id="price">
+        <h3>Прайс-лист</h3>
+        <table class="price">
+          <tr>
+            <th>Услуга</th>
+            <th>Время</th>
+            <th>Цена</th>
+          </tr>
+          <tr>
+            <td>Нарощування нігтів</td>
+            <td>60 хв</td>
+            <td>550 грн</td>
+          </tr>
+          <tr>
+            <td>Корекція з манікюром</td>
+            <td>60 хв</td>
+            <td>450 грн</td>
+          </tr>
+          <tr>
+            <td>Корекція без манікюру</td>
+            <td>60 хв</td>
+            <td>400 грн</td>
+          </tr>
+          <tr>
+            <td>Покриття нігтів з укріпленням + манікюр</td>
+            <td>60 хв</td>
+            <td>450 грн</td>
+          </tr>
+        </table>
+        <div class="photo-placeholder"></div>
+      </section>
+    </main>
+    <footer>
+      <p>© Studiya Ludmila, 2023</p>
+    </footer>
+  </body>
+</html>

--- a/massage.html
+++ b/massage.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Профессиональный массаж в Studiya Ludmila: расслабление и забота о вашем теле."
+    />
+    <title>Массаж</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&family=Playfair+Display:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="branding">
+        <img
+          src="photo/logo/logo.png"
+          alt="Studiya Ludmila logo"
+          class="logo"
+        />
+        <h1>Studiya Ludmila</h1>
+      </div>
+      <nav>
+        <a href="index.html">Главная</a>
+        <a href="permanent.html">Перманентный макияж</a>
+        <a href="hair.html">Парикмахер</a>
+        <a href="massage.html" class="active">Массаж</a>
+        <a href="manicure.html">Маникюр</a>
+        <a href="laser.html">Лазерные процедуры</a>
+      </nav>
+    </header>
+    <main>
+      <section class="hero">
+        <h2>Массаж</h2>
+        <p>
+          Почувствуйте лёгкость и гармонию. Наши специалисты снимают напряжение,
+          возвращают тонус и улучшают самочувствие. Забронируйте своё время
+          отдыха!
+        </p>
+        <a href="#price" class="cta-button">Записаться</a>
+      </section>
+      <section id="price">
+        <h3>Прайс-лист</h3>
+        <table class="price">
+          <tr>
+            <th>Услуга</th>
+            <th>Длительность</th>
+            <th>Цена</th>
+          </tr>
+          <tr>
+            <td>Масаж обличчя</td>
+            <td>45 хв</td>
+            <td>450 грн</td>
+          </tr>
+          <tr>
+            <td>Масаж шийно-комірцевої зони</td>
+            <td>60 хв</td>
+            <td>350 грн</td>
+          </tr>
+          <tr>
+            <td>Баночний масаж</td>
+            <td>90 хв</td>
+            <td>400 грн</td>
+          </tr>
+          <tr>
+            <td>Класичний масаж всього тіла</td>
+            <td>120 хв</td>
+            <td>500 грн</td>
+          </tr>
+          <tr>
+            <td>Лімфодренуючий масаж всього тіла</td>
+            <td>120 хв</td>
+            <td>500 грн</td>
+          </tr>
+          <tr>
+            <td>Масаж спини</td>
+            <td>90 хв</td>
+            <td>400 грн</td>
+          </tr>
+          <tr>
+            <td>Масаж рук</td>
+            <td>60 хв</td>
+            <td>300 грн</td>
+          </tr>
+          <tr>
+            <td>Медовий масаж</td>
+            <td>60 хв</td>
+            <td>350 грн</td>
+          </tr>
+          <tr>
+            <td>Масаж ніг</td>
+            <td>60 хв</td>
+            <td>300 грн</td>
+          </tr>
+          <tr>
+            <td>Антицелюлітний масаж</td>
+            <td>120 хв</td>
+            <td>500 грн</td>
+          </tr>
+        </table>
+        <div class="photo-placeholder"></div>
+      </section>
+    </main>
+    <footer>
+      <p>© Studiya Ludmila, 2023</p>
+    </footer>
+  </body>
+</html>

--- a/permanent.html
+++ b/permanent.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Перманентный макияж в Studiya Ludmila: брови, губы, стрелки, межресничка."
+    />
+    <title>Перманентный макияж</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&family=Playfair+Display:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="branding">
+        <img
+          src="photo/logo/logo.png"
+          alt="Studiya Ludmila logo"
+          class="logo"
+        />
+        <h1>Studiya Ludmila</h1>
+      </div>
+      <nav>
+        <a href="index.html">Главная</a>
+        <a href="permanent.html" class="active">Перманентный макияж</a>
+        <a href="hair.html">Парикмахер</a>
+        <a href="massage.html">Массаж</a>
+        <a href="manicure.html">Маникюр</a>
+        <a href="laser.html">Лазерные процедуры</a>
+      </nav>
+    </header>
+    <main>
+      <section class="hero">
+        <h2>Перманентный макияж</h2>
+        <p>
+          Просыпайтесь красивой каждый день. Стойкий перманентный макияж
+          подчеркнёт вашу природную привлекательность. Приходите за идеальным
+          образом!
+        </p>
+        <a href="#price" class="cta-button">Записаться</a>
+      </section>
+      <section id="price">
+        <h3>Прайс-лист</h3>
+        <table class="price">
+          <tr>
+            <th>Услуга</th>
+            <th>Время</th>
+            <th>Цена</th>
+          </tr>
+          <tr>
+            <td>Брови</td>
+            <td>90 хв</td>
+            <td>1200 грн</td>
+          </tr>
+          <tr>
+            <td>Стрілки</td>
+            <td>90 хв</td>
+            <td>1200 грн</td>
+          </tr>
+          <tr>
+            <td>Губи</td>
+            <td>90 хв</td>
+            <td>1200 грн</td>
+          </tr>
+          <tr>
+            <td>Міжвійка</td>
+            <td>90 хв</td>
+            <td>1200 грн</td>
+          </tr>
+          <tr>
+            <td>Корекція перманентного макіяжу (1 зона)</td>
+            <td>60 хв</td>
+            <td>600 грн</td>
+          </tr>
+        </table>
+        <div class="photo-placeholder"></div>
+      </section>
+    </main>
+    <footer>
+      <p>© Studiya Ludmila, 2023</p>
+    </footer>
+  </body>
+</html>

--- a/photo/back_general/.gitkeep
+++ b/photo/back_general/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder for general background image

--- a/photo/logo/.gitkeep
+++ b/photo/logo/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder for logo image

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,173 @@
+body {
+  font-family: "Montserrat", sans-serif;
+  background-color: #f6f1ec;
+  color: #2e2821;
+  margin: 0;
+  padding: 0;
+  scroll-behavior: smooth;
+}
+
+h1,
+h2,
+h3 {
+  font-family: "Playfair Display", serif;
+}
+
+header,
+nav,
+footer {
+  background: linear-gradient(135deg, #2e2821, #4b3d35);
+  color: #f6f1ec;
+  text-align: center;
+}
+
+header,
+footer {
+  padding: 0.5rem;
+}
+
+nav {
+  padding: 0.25rem;
+}
+
+nav a {
+  color: #f6f1ec;
+  margin: 0 10px;
+  text-decoration: none;
+  position: relative;
+}
+
+nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 0;
+  height: 2px;
+  background: #d4b59f;
+  transition: width 0.3s;
+}
+
+nav a:hover::after {
+  width: 100%;
+}
+
+nav a:hover {
+  color: #d4b59f;
+}
+
+nav a.active {
+  color: #d4b59f;
+}
+
+nav a.active::after {
+  width: 100%;
+}
+
+main {
+  padding: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+section {
+  margin-bottom: 2rem;
+  animation: fadeUp 0.8s ease-in;
+}
+
+.hero {
+  text-align: center;
+  padding: 4rem 1rem;
+  background:
+    linear-gradient(rgba(46, 40, 33, 0.8), rgba(46, 40, 33, 0.8)),
+    url("photo/index/hero.jpg") center/cover no-repeat;
+  color: #f6f1ec;
+}
+
+.cta-button {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: #d4b59f;
+  color: #2e2821;
+  border-radius: 30px;
+  text-decoration: none;
+  font-weight: 600;
+  transition:
+    transform 0.3s,
+    box-shadow 0.3s;
+}
+
+.cta-button:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.photo-placeholder {
+  width: 100%;
+  max-width: 400px;
+  height: 250px;
+  background-color: #ddd;
+  border: 2px dashed #2e2821;
+  margin-top: 1rem;
+  animation: pulse 2s infinite;
+}
+
+.hero-photo {
+  width: 100%;
+  height: 300px;
+  border-radius: 15px;
+  background: url("photo/back_general/hero.jpg") center/cover no-repeat;
+  margin-top: 1rem;
+}
+
+.branding {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.logo {
+  height: 50px;
+}
+
+header h1 {
+  margin: 0;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(46, 40, 33, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(46, 40, 33, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(46, 40, 33, 0);
+  }
+}
+
+table.price {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+table.price th,
+table.price td {
+  border-bottom: 1px solid #2e2821;
+  padding: 0.75rem;
+  text-align: left;
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Summary
- Rename site to "Studiya Ludmila" and add a slimmer header with a visible logo
- Highlight the current page in navigation and widen the home hero block for a background image
- Prepare placeholder folders for logo and general background assets

## Testing
- `npx --yes prettier --check "*.html" "styles.css"`


------
https://chatgpt.com/codex/tasks/task_e_689cbb3e1af4832aa8d23ad601974643